### PR TITLE
JBIDE-13305 - close started browsersim when closing eclipse/jbds

### DIFF
--- a/plugins/org.jboss.tools.vpe.browsersim.eclipse/src/org/jboss/tools/vpe/browsersim/eclipse/util/BrowserSimLauncher.java
+++ b/plugins/org.jboss.tools.vpe.browsersim.eclipse/src/org/jboss/tools/vpe/browsersim/eclipse/util/BrowserSimLauncher.java
@@ -23,12 +23,13 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.eclipse.osgi.framework.internal.core.BundleFragment;
 import org.eclipse.osgi.framework.internal.core.BundleHost;
+import org.eclipse.ui.IWorkbenchListener;
+import org.eclipse.ui.PlatformUI;
 import org.jboss.tools.vpe.browsersim.browser.PlatformUtil;
 import org.jboss.tools.vpe.browsersim.eclipse.Activator;
 import org.jboss.tools.vpe.browsersim.eclipse.callbacks.BrowserSimCallback;
 import org.jboss.tools.vpe.browsersim.eclipse.callbacks.OpenFileCallback;
 import org.jboss.tools.vpe.browsersim.eclipse.callbacks.ViewSourceCallback;
-import org.jboss.tools.vpe.browsersim.ui.BrowserSim;
 import org.osgi.framework.Bundle;
 
 /**
@@ -96,7 +97,9 @@ public class BrowserSimLauncher {
 			processBuilder.directory(ConfigurationScope.INSTANCE.getLocation().toFile());
 			
 			Process browserSimProcess = processBuilder.start();
-
+			final IWorkbenchListener browserSimPostShutDownDestroyer = new BrowserSimPostShutDownDestroyer(browserSimProcess);
+			PlatformUI.getWorkbench().addWorkbenchListener(browserSimPostShutDownDestroyer);
+			
 			final InputStreamReader errorReader = new InputStreamReader(browserSimProcess.getErrorStream());
 			final Reader inputReader = new InputStreamReader(browserSimProcess.getInputStream());
 			new Thread() {
@@ -113,6 +116,8 @@ public class BrowserSimLauncher {
 						}
 					} catch (IOException e) {
 						e.printStackTrace();
+					}  finally {
+						PlatformUI.getWorkbench().removeWorkbenchListener(browserSimPostShutDownDestroyer);
 					}
 				};
 			}.start();

--- a/plugins/org.jboss.tools.vpe.browsersim.eclipse/src/org/jboss/tools/vpe/browsersim/eclipse/util/BrowserSimPostShutDownDestroyer.java
+++ b/plugins/org.jboss.tools.vpe.browsersim.eclipse/src/org/jboss/tools/vpe/browsersim/eclipse/util/BrowserSimPostShutDownDestroyer.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2007-2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.vpe.browsersim.eclipse.util;
+
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchListener;
+
+public class BrowserSimPostShutDownDestroyer implements IWorkbenchListener {
+
+	Process browserSimProcess;
+
+	public BrowserSimPostShutDownDestroyer(Process browserSimProcess) {
+		this.browserSimProcess = browserSimProcess;
+	}
+
+	@Override
+	public boolean preShutdown(IWorkbench workbench, boolean forced) {
+		return true;
+	}
+
+	@Override
+	public void postShutdown(IWorkbench workbench) {
+		browserSimProcess.destroy();
+	}
+}


### PR DESCRIPTION
Closing all browsersims after exiting eclipse workbench
