### PR TITLE
JBIDE-13476: Removed bootstrap profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,4 @@
 		<module>features</module>
 		<module>site</module>
 	</modules>
-	<profiles>
-		<profile>
-			<id>bootstrap</id>
-			<modules>
-				<module>../jbosstools-xulrunner</module>
-				<module>../jbosstools-jst</module>
-				<module>../jbosstools-base</module>
-			</modules>
-		</profile>
-	</profiles>
 </project>

--- a/products/pom.xml
+++ b/products/pom.xml
@@ -11,18 +11,9 @@
 	<packaging>pom</packaging>
 
 	<modules>
+		<module>../plugins/org.jboss.tools.vpe.browsersim</module>
+		<module>../plugins/org.jboss.tools.vpe.browsersim.browser</module>
 		<module>browsersim-standalone</module>
 	</modules>
-
-	
-	<profiles>
-		<profile>
-			<id>bootstrap</id>
-			<modules>
-				<module>../plugins/org.jboss.tools.vpe.browsersim</module>
-				<module>../plugins/org.jboss.tools.vpe.browsersim.browser</module>
-			</modules>
-		</profile>
-	</profiles>
 
 </project>


### PR DESCRIPTION
- bootstrap profile in main pom is useless
- bootstrap profile in products is useless because it's already part of an independant pom.
