### PR TITLE
JBIDE-14986 BrowserSim: cannot run BrowserSim on 64-bit Eclipse on Windows with Java 7

### DIFF
--- a/plugins/org.jboss.tools.vpe.browsersim.eclipse/src/org/jboss/tools/vpe/browsersim/eclipse/launcher/ExternalProcessLauncher.java
+++ b/plugins/org.jboss.tools.vpe.browsersim.eclipse/src/org/jboss/tools/vpe/browsersim/eclipse/launcher/ExternalProcessLauncher.java
@@ -61,21 +61,6 @@ public class ExternalProcessLauncher {
 			
 			if (!jvmPath.isEmpty()) {
 				String javaCommand = jvmPath + "/bin/java"; //$NON-NLS-1$ //$NON-NLS-2$
-				//String javaCommand = System.getProperty("java.home") + "/bin/java"; //$NON-NLS-1$ //$NON-NLS-2$
-				
-				// This is a workaround for JDK 7: JBIDE-12467 Unable to Run Browsersim in Windows7 64b + JRE7 32b
-				// On Windows and Java 7 the 'java.home' variable always points to JRE, but 'eclipse.vm' may point to JDK,
-				// if it is specified explicitly in the eclipse.ini.
-				boolean isJava1_7 = "1.7".equals(System.getProperty("java.specification.version")); //$NON-NLS-1$ //$NON-NLS-2$
-				if (Platform.OS_WIN32.equals(Platform.getOS()) && isJava1_7) {
-					String eclipseVm = System.getProperty("eclipse.vm");
-					if (eclipseVm != null) {
-						if (eclipseVm.endsWith("java") || eclipseVm.endsWith("java.exe") 
-								|| eclipseVm.endsWith("javaw") || eclipseVm.endsWith("javaw.exe")) {
-							javaCommand = eclipseVm;
-						}
-					}
-				}
 				
 				List<String> commandElements = new ArrayList<String>();
 				commandElements.add(javaCommand);


### PR DESCRIPTION
fixed
