### PR TITLE
JBIDE-15120 BrowserSim does not launch on Java 6 32-bit JVM Mac OS X when Java 7 or Java 5 installed

### DIFF
--- a/plugins/org.jboss.tools.vpe.browsersim.eclipse/src/org/jboss/tools/vpe/browsersim/eclipse/dialog/BrowserSimErrorDialog.java
+++ b/plugins/org.jboss.tools.vpe.browsersim.eclipse/src/org/jboss/tools/vpe/browsersim/eclipse/dialog/BrowserSimErrorDialog.java
@@ -18,6 +18,7 @@ import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.PreferencesUtil;
+import org.jboss.tools.vpe.browsersim.browser.PlatformUtil;
 
 public class BrowserSimErrorDialog extends MessageDialog {
 	private static final String BROWSERSIM_PREFERENCE_PAGE_ID = "org.jboss.tools.vpe.browsersim.eclipse.preferences.BrowserSimPreferences";
@@ -39,11 +40,16 @@ public class BrowserSimErrorDialog extends MessageDialog {
         data.horizontalSpan = 2;
         link.setData(data);
 		
-        String message;
-		if (Platform.OS_WIN32.equals(Platform.getOS())) {
+		String message;
+		String os = Platform.getOS();
+		boolean is32bitEclipse = PlatformUtil.ARCH_X86.equals(PlatformUtil.getArch());
+		if (Platform.OS_WIN32.equals(os)) {
 			message = "{0} requires a 32-bit JRE/JDK 6 or JDK 7 to run on Windows.\nPlease go to the <a href=\"#\">{1} preferences</a> and select an appropriate JVM.";
-		} else {
-			message = "{0} requires Java 6 and above to be installed.\nPlease go to the <a href=\"#\">{1} preferences</a> and select an appropriate JVM.";
+		} else if (Platform.OS_MACOSX.equals(os) && is32bitEclipse) {
+			message = "{0} requires Java 6 to be installed.\nPlease go to the <a href=\"#\">{1} preferences</a> and select an appropriate JVM.";
+		} else {// Linux, 64-bit Mac
+			message = "{0} requires " + (is32bitEclipse ? "32-bit" : "64-bit")
+					+ " Java 6 and above to be installed.\nPlease go to the <a href=\"#\">{1} preferences</a> and select an appropriate JVM.";
 		}
 		
 		IPreferenceNode jreNode = getPreferenceNode(BROWSERSIM_PREFERENCE_PAGE_ID);

--- a/plugins/org.jboss.tools.vpe.browsersim.eclipse/src/org/jboss/tools/vpe/browsersim/eclipse/preferences/BrowserSimPreferencesPage.java
+++ b/plugins/org.jboss.tools.vpe.browsersim.eclipse/src/org/jboss/tools/vpe/browsersim/eclipse/preferences/BrowserSimPreferencesPage.java
@@ -140,12 +140,15 @@ public class BrowserSimPreferencesPage extends PreferencePage implements IWorkbe
 			 * @see https://issues.jboss.org/browse/JBIDE-13988
 			 */
 			String message;
-			if (Platform.OS_WIN32.equals(Platform.getOS())) {
+			String os = Platform.getOS();
+			boolean is32bitEclipse = PlatformUtil.ARCH_X86.equals(PlatformUtil.getArch());
+			if (Platform.OS_WIN32.equals(os)) {
 				message = "BrowserSim/CordovaSim require a 32-bit JRE/JDK 6 or JDK 7 to be installed.";
-			} else if (PlatformUtil.OS_MACOSX.equals(PlatformUtil.getOs()) && PlatformUtil.ARCH_X86.equals(PlatformUtil.getArch())) {
-				message = "To run BrowserSim/CordovaSim with Java 7 you must run 64-bit Eclipse or use Java 6.";
-			} else {
-				message = "BrowserSim/CordovaSim require Java 6 and above to be installed.";
+			} else if (PlatformUtil.OS_MACOSX.equals(os) && is32bitEclipse) {
+				message = "To run BrowserSim/CordovaSim from 32-bit Eclipse you must use Java 6.";
+			} else {// Linux, 64-bit Mac
+				message = "BrowserSim/CordovaSim require " + (is32bitEclipse ? "32-bit" : "64-bit")
+						+ " Java 6 and above to be installed.";
 			}
 			setMessage(message, IMessageProvider.ERROR);//$NON-NLS-1$
 			automatically.setSelection(true);


### PR DESCRIPTION
- added a check for Java 6 or higher
- added a check for SWT arch on Linux
- edited messages
