### PR TITLE
JBIDE-18748: Remove ref to macosx x86 feature

### DIFF
--- a/features/org.jboss.tools.xulrunner.feature/feature.xml
+++ b/features/org.jboss.tools.xulrunner.feature/feature.xml
@@ -25,15 +25,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.mozilla.xulrunner.cocoa.macosx"
-         os="macosx"
-         ws="cocoa"
-         arch="x86"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>
-
-   <plugin
          id="org.mozilla.xulrunner.gtk.linux.x86"
          os="linux"
          ws="gtk"


### PR DESCRIPTION
macosx/cocoa/x86 isn't supported any more. Remove reference
to the platform-specific feature.
