### PR TITLE
JBIDE-19774 Visual Editor: XulRunner Engine on Linux is always used i…

### DIFF
--- a/features/org.jboss.tools.vpe.test.feature/feature.xml
+++ b/features/org.jboss.tools.vpe.test.feature/feature.xml
@@ -75,4 +75,10 @@
          install-size="0"
          version="0.0.0"/>
 
+  <plugin
+         id="org.jboss.tools.xulrunner.initializer"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"/>
 </feature>

--- a/plugins/org.jboss.tools.vpe.preview.editor/src/org/jboss/tools/vpe/preview/editor/VpeEditorPartFactory.java
+++ b/plugins/org.jboss.tools.vpe.preview.editor/src/org/jboss/tools/vpe/preview/editor/VpeEditorPartFactory.java
@@ -31,15 +31,9 @@ import org.jboss.tools.vpe.preview.core.util.SuitableFileExtensions;
  * @author Konstantin Marmalyukov (kmarmaliykov)
  */
 public class VpeEditorPartFactory implements IVisualEditorFactory {	
-	private static final String WEBKIT_ENABLED_BY_VPE_USER_SYSTEM_PROPERTY = "org.jboss.tools.vpe.webkit.enabledbyuser"; //$NON-NLS-1$
-	
 	static {
 		//Since we do not implement the option of showing Visual toolbar for preview editor into Eclipse toolbar - must always show visual toolbar within the editor
-	    WebUiPlugin.getDefault().getPreferenceStore().setValue(IVpePreferencesPage.SHOW_VISUAL_TOOLBAR, true);
-	    //set this property to see which browser engine was chosen before start(xulrunner is default)
-	    System.setProperty(WEBKIT_ENABLED_BY_VPE_USER_SYSTEM_PROPERTY,
-	    		Boolean.toString(WebUiPlugin.getDefault().getPreferenceStore().getBoolean(IVpePreferencesPage.USE_VISUAL_EDITOR_FOR_HTML5)));
-	    
+	    WebUiPlugin.getDefault().getPreferenceStore().setValue(IVpePreferencesPage.SHOW_VISUAL_TOOLBAR, true);	    
 	}
 	
 	public IVisualEditor createVisualEditor(final EditorPart multiPageEditor, StructuredTextEditor textEditor, int visualMode, BundleMap bundleMap) {

--- a/plugins/org.jboss.tools.vpe.xulrunner/src/org/jboss/tools/vpe/xulrunner/BrowserPlugin.java
+++ b/plugins/org.jboss.tools.vpe.xulrunner/src/org/jboss/tools/vpe/xulrunner/BrowserPlugin.java
@@ -14,7 +14,6 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.jboss.tools.common.log.BaseUIPlugin;
 import org.jboss.tools.common.log.IPluginLog;
-import org.jboss.tools.vpe.xulrunner.browser.XulRunnerBrowser;
 import org.osgi.framework.BundleContext;
 
 /**
@@ -51,8 +50,6 @@ public class BrowserPlugin extends BaseUIPlugin {
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
 		plugin = this;
-		// required to be here to fix tycho test execution errors
-		earlyStartup();
 	}
 
 	/*
@@ -86,18 +83,5 @@ public class BrowserPlugin extends BaseUIPlugin {
 	
 	public static IPluginLog getPluginLog() {
 		return getDefault();
-	}
-	
-	public void earlyStartup() {
-		try {
-			/* init xulrunner path  */ 
-			XulRunnerBrowser.getXulRunnerPath();
-//			String xulRunnerPath = XulRunnerBrowser.getXulRunnerPath();
-//			if ("true".equals(Platform.getDebugOption(PLUGIN_ID + "/debug/earlyStartup"))) { //$NON-NLS-1$ //$NON-NLS-2$
-//				logInfo(MessageFormat.format("earlyStartup: XULRunner path is: {0}",xulRunnerPath)); //$NON-NLS-1$
-//			}
-		} catch (XulRunnerException e) {
-			logError(e);
-		}
 	}
 }

--- a/plugins/org.jboss.tools.xulrunner.initializer/src/org/eclipse/swt/browser/WebKitInitializer.java
+++ b/plugins/org.jboss.tools.xulrunner.initializer/src/org/eclipse/swt/browser/WebKitInitializer.java
@@ -4,8 +4,6 @@ package org.eclipse.swt.browser;
 public class WebKitInitializer {
 
 	private static final String USE_WEB_KIT_GTK = "org.eclipse.swt.browser.UseWebKitGTK"; //$NON-NLS-1$
-	private static final String WEBKIT_ENABLED_BY_VPE_USER_SYSTEM_PROPERTY = "org.jboss.tools.vpe.webkit.enabledbyuser"; //$NON-NLS-1$
-	public static boolean WEBKIT_ENABLED_BY_USER = "true".equals(System.getProperty(WEBKIT_ENABLED_BY_VPE_USER_SYSTEM_PROPERTY)); //$NON-NLS-1$
 	
 	static {
 		String useWebKitGTK = System.getProperty(USE_WEB_KIT_GTK);

--- a/plugins/org.jboss.tools.xulrunner.initializer/src/org/eclipse/swt/browser/XULRunnerInitializer.java
+++ b/plugins/org.jboss.tools.xulrunner.initializer/src/org/eclipse/swt/browser/XULRunnerInitializer.java
@@ -9,10 +9,11 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.osgi.util.NLS;
 import org.osgi.framework.Bundle;
 
+import static org.eclipse.swt.browser.BrowserInitializer.XULRUNNER_PATH;
+
 public class XULRunnerInitializer {
 
 	private static final String FALSE = "false"; //$NON-NLS-1$
-	private static final String XULRUNNER_PATH = "org.eclipse.swt.browser.XULRunnerPath"; //$NON-NLS-1$
 	private static final String XULRUNNER_ENTRY = "/xulrunner"; //$NON-NLS-1$
 	
 	/* XXX: yradtsevich: these constants are duplicated

--- a/tests/org.jboss.tools.vpe.base.test/src/org/jboss/tools/vpe/base/test/VpeTest.java
+++ b/tests/org.jboss.tools.vpe.base.test/src/org/jboss/tools/vpe/base/test/VpeTest.java
@@ -80,6 +80,7 @@ public class VpeTest extends TestCase implements ILogListener {
 	static {
 		//set this property to make VPE always opened as visual part
 		System.setProperty(VpePlatformUtil.LOAD_XULRUNNER_ENGINE, String.valueOf(true));
+		WebUiPlugin.getDefault().getPreferenceStore().setValue(IVpePreferencesPage.USE_VISUAL_EDITOR_FOR_HTML5, Boolean.FALSE.toString());
 	}
 	
 	/**

--- a/tests/org.jboss.tools.vpe.jst.test/src/org/jboss/tools/vpe/jst/test/VpeJstAllTests.java
+++ b/tests/org.jboss.tools.vpe.jst.test/src/org/jboss/tools/vpe/jst/test/VpeJstAllTests.java
@@ -13,6 +13,8 @@ package org.jboss.tools.vpe.jst.test;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
+import org.jboss.tools.jst.web.ui.WebUiPlugin;
+import org.jboss.tools.jst.web.ui.internal.editor.preferences.IVpePreferencesPage;
 import org.jboss.tools.test.util.ProjectImportTestSetup;
 import org.jboss.tools.vpe.editor.util.VpePlatformUtil;
 import org.jboss.tools.vpe.jst.angularjs.test.ca.AngularDynamicCATest;
@@ -25,6 +27,7 @@ public class VpeJstAllTests {
 	public static Test suite() {
 		// set this property to make VPE always opened as visual part
 		System.setProperty(VpePlatformUtil.LOAD_DEFAULT_ENGINE, String.valueOf(true));
+		WebUiPlugin.getDefault().getPreferenceStore().setValue(IVpePreferencesPage.USE_VISUAL_EDITOR_FOR_HTML5, Boolean.TRUE.toString());
 		
 		TestSuite suite = new TestSuite(VpeJstAllTests.class.getName());
 

--- a/tests/org.jboss.tools.vpe.preview.editor.test/src/org/jboss/tools/vpe/preview/editor/test/HTMLEditorAllImportantTests.java
+++ b/tests/org.jboss.tools.vpe.preview.editor.test/src/org/jboss/tools/vpe/preview/editor/test/HTMLEditorAllImportantTests.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package org.jboss.tools.vpe.preview.editor.test;
 
+import org.jboss.tools.jst.web.ui.WebUiPlugin;
+import org.jboss.tools.jst.web.ui.internal.editor.preferences.IVpePreferencesPage;
 import org.jboss.tools.vpe.editor.util.VpePlatformUtil;
 import org.jboss.tools.vpe.preview.editor.test.editor.OpenEditorTest;
 import org.jboss.tools.vpe.preview.editor.test.editor.PreviewReloadTest;
@@ -36,5 +38,6 @@ public class HTMLEditorAllImportantTests {
 	public static void initialize() {
 		// set this property to make VPE always opened as visual part
 		System.setProperty(VpePlatformUtil.LOAD_DEFAULT_ENGINE, String.valueOf(true));
+		WebUiPlugin.getDefault().getPreferenceStore().setValue(IVpePreferencesPage.USE_VISUAL_EDITOR_FOR_HTML5, Boolean.TRUE.toString());
 	}
 }

--- a/tests/org.jboss.tools.vpe.preview.editor.test/src/org/jboss/tools/vpe/preview/editor/test/HTMLEditorAllTests.java
+++ b/tests/org.jboss.tools.vpe.preview.editor.test/src/org/jboss/tools/vpe/preview/editor/test/HTMLEditorAllTests.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package org.jboss.tools.vpe.preview.editor.test;
 
+import org.jboss.tools.jst.web.ui.WebUiPlugin;
+import org.jboss.tools.jst.web.ui.internal.editor.preferences.IVpePreferencesPage;
 import org.jboss.tools.vpe.editor.util.VpePlatformUtil;
 import org.jboss.tools.vpe.preview.editor.test.editor.OpenEditorTest;
 import org.jboss.tools.vpe.preview.editor.test.editor.PreviewReloadTest;
@@ -36,5 +38,6 @@ public class HTMLEditorAllTests {
 	public static void initialize() {
 		// set this property to make VPE always opened as visual part
 		System.setProperty(VpePlatformUtil.LOAD_DEFAULT_ENGINE, String.valueOf(true));
+		WebUiPlugin.getDefault().getPreferenceStore().setValue(IVpePreferencesPage.USE_VISUAL_EDITOR_FOR_HTML5, Boolean.TRUE.toString());
 	}
 }


### PR DESCRIPTION
…f browser was opened before Visual Editor

fixed browser initialization process
preferences of required browser now stored in eclipse preferences