### PR TITLE
[JBIDE-20411] UI Lock with HTMLPreview opened

### DIFF
--- a/plugins/org.jboss.tools.vpe.preview/src/org/jboss/tools/vpe/preview/view/VpvView.java
+++ b/plugins/org.jboss.tools.vpe.preview/src/org/jboss/tools/vpe/preview/view/VpvView.java
@@ -236,17 +236,11 @@ public class VpvView extends ViewPart implements VpvVisualModelHolder {
 				@Override
 				public void documentChanged(DocumentEvent event) {
 					if (actionBar.isAutomaticRefreshEnabled()) {
-						String fileExtension = EditorUtil.getFileExtensionFromEditor(currentEditor);
-						if (SuitableFileExtensions.isCssOrJs(fileExtension)) {
-							currentEditor.doSave(new NullProgressMonitor()); // saving all js and css stuff
-						}
 						updatePreview();
 					}
 				}
-
 			};
 		}
-
 		return documentListener;
 	}
 


### PR DESCRIPTION
Fix removes code that runs save workspace operation from document change even
which is workspace operation itself.