### PR TITLE
JBIDE-22323: explicit requirement on javax.annotation

### DIFF
--- a/tests/org.jboss.tools.vpe.ui.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.vpe.ui.test/META-INF/MANIFEST.MF
@@ -22,7 +22,8 @@ Require-Bundle: org.eclipse.ui,
  javax.servlet;bundle-version="2.5.0",
  org.eclipse.wst.xml.xpath.core,
  org.jboss.tools.vpe.base.test;bundle-version="1.0.0",
- org.eclipse.wst.html.core
+ org.eclipse.wst.html.core,
+ javax.annotation
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
  lib/jmock-2.5.1/jmock-2.5.1.jar,


### PR DESCRIPTION
This package was most likely previously re-exported by some other
bundle, but this seems to have changed with M7, so let's simply
make the dependency explicit.