### PR TITLE
JBIDE-22692: Add missing copyright headers

### DIFF
--- a/tests/org.jboss.tools.vpe.preview.editor.test/src/org/jboss/tools/vpe/preview/editor/test/editor/VpvToolBarTest.java
+++ b/tests/org.jboss.tools.vpe.preview.editor.test/src/org/jboss/tools/vpe/preview/editor/test/editor/VpvToolBarTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.vpe.preview.editor.test.editor;
 
 import static org.jboss.tools.vpe.preview.core.preferences.VpvPreferencesInitializer.REFRESH_ON_CHANGE_PREFERENCES;

--- a/tests/org.jboss.tools.vpe.preview.editor.test/src/org/jboss/tools/vpe/preview/editor/test/util/ActionIsEnabledCondition.java
+++ b/tests/org.jboss.tools.vpe.preview.editor.test/src/org/jboss/tools/vpe/preview/editor/test/util/ActionIsEnabledCondition.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.vpe.preview.editor.test.util;
 
 import org.eclipse.jface.action.ActionContributionItem;

--- a/tests/org.jboss.tools.vpe.preview.editor.test/src/org/jboss/tools/vpe/preview/editor/test/util/RefreshDelayHelper.java
+++ b/tests/org.jboss.tools.vpe.preview.editor.test/src/org/jboss/tools/vpe/preview/editor/test/util/RefreshDelayHelper.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.vpe.preview.editor.test.util;
 
 import org.jboss.tools.test.util.xpl.DisplayHelper;


### PR DESCRIPTION
All classes in o.j.t.vpe.preview.editor.test now contain copyright header