### PR TITLE
JBIDE-23211: JS Alert popups are not disabled on Windows

### DIFF
--- a/plugins/org.jboss.tools.vpe.preview.editor/src/org/jboss/tools/vpe/preview/editor/VpvEditor.java
+++ b/plugins/org.jboss.tools.vpe.preview.editor/src/org/jboss/tools/vpe/preview/editor/VpvEditor.java
@@ -34,6 +34,8 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.browser.LocationAdapter;
 import org.eclipse.swt.browser.LocationEvent;
+import org.eclipse.swt.browser.TitleEvent;
+import org.eclipse.swt.browser.TitleListener;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.events.MouseAdapter;
@@ -419,13 +421,20 @@ public class VpvEditor extends DocumentListeningEditorPart implements VpvVisualM
 			browser.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 			browser.addLocationListener(new LocationAdapter() {
 				@Override
-				public void changed(LocationEvent event) {
+				public void changed(LocationEvent event) {					
+					ISelection currentSelection = getCurrentSelection();
+					NavigationUtil.updateSelectionAndScrollToIt(currentSelection, browser, visualModel);
+				}
+			});
+			
+			browser.addTitleListener(new TitleListener() {
+				
+				@Override
+				public void changed(TitleEvent event) {
 					NavigationUtil.disableJsPopUps(browser);
 					NavigationUtil.disableLinks(browser);
 					NavigationUtil.disableInputs(browser);
 					
-					ISelection currentSelection = getCurrentSelection();
-					NavigationUtil.updateSelectionAndScrollToIt(currentSelection, browser, visualModel);
 				}
 			});
 			

--- a/plugins/org.jboss.tools.vpe.preview/src/org/jboss/tools/vpe/preview/view/VpvView.java
+++ b/plugins/org.jboss.tools.vpe.preview/src/org/jboss/tools/vpe/preview/view/VpvView.java
@@ -32,6 +32,8 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.browser.LocationAdapter;
 import org.eclipse.swt.browser.LocationEvent;
+import org.eclipse.swt.browser.TitleEvent;
+import org.eclipse.swt.browser.TitleListener;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.layout.FillLayout;
@@ -120,10 +122,6 @@ public class VpvView extends ViewPart implements VpvVisualModelHolder {
 			browser.addLocationListener(new LocationAdapter() {
 				@Override
 				public void changed(LocationEvent event) {
-					NavigationUtil.disableJsPopUps(browser);
-					NavigationUtil.disableLinks(browser);
-					NavigationUtil.disableInputs(browser);
-
 					ISelection currentSelection = getCurrentSelection();
 					NavigationUtil.updateSelectionAndScrollToIt(currentSelection, browser, visualModel);
 				}
@@ -135,6 +133,17 @@ public class VpvView extends ViewPart implements VpvVisualModelHolder {
 					NavigationUtil.navigateToVisual(currentEditor, browser, visualModel, event.x, event.y);
 				}
 
+			});
+			
+			browser.addTitleListener(new TitleListener() {
+				
+				@Override
+				public void changed(TitleEvent event) {
+					NavigationUtil.disableJsPopUps(browser);
+					NavigationUtil.disableLinks(browser);
+					NavigationUtil.disableInputs(browser);
+					
+				}
 			});
 	
 			inizializeSelectionListener();


### PR DESCRIPTION
progress listener is notified too soon on windows machines. The only listener that is called in right time to disable JS/links/... on all platforms is TitleListener. Tested on Mac,Windows 8.1, 10 and RHEL